### PR TITLE
Fixing a build failure when all modules are built.

### DIFF
--- a/pkg/jwt/github/client.go
+++ b/pkg/jwt/github/client.go
@@ -46,7 +46,7 @@ func (c *client) Teams(httpClient *http.Client) (OrganizationTeams, error) {
 	organizationTeams := OrganizationTeams{}
 
 	for nextPage != 0 {
-		teams, resp, err := client.Organizations.ListUserTeams(context.TODO(), &github.ListOptions{Page: nextPage})
+		teams, resp, err := client.Teams.ListUserTeams(context.TODO(), &github.ListOptions{Page: nextPage})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Accessing `client.Organizations.ListUserTeams` is incorrect. The correct way to get user teams is:

    client.Teams.ListUserTeams

## What does this PR do?
A few sentences describing the overall goals of the pull request's commits.
